### PR TITLE
Remove Dillon Ze Chen from PRL 2026 organizing committee

### DIFF
--- a/caipi_prl2026-ijcai/README.md
+++ b/caipi_prl2026-ijcai/README.md
@@ -94,7 +94,6 @@ We do not insist on papers being submitted anonymously initially; this decision 
 ## Organizing Committee
 * [Forest Agostinelli](https://cse.sc.edu/%7Eforesta/), University of South Carolina, Columbia, USA.
 * [Zlatan Ajanović](https://zlatanajanovic.com), RWTH Aachen University, Aachen, Germany.
-* [Dillon Ze Chen](https://dillonzchen.github.io), Laboratory for Analysis and Architecture of Systems (LAAS-CNRS), Toulouse, France.
 * Jonas Erhardt, Helmut-Schmidt-University, Hamburg, Germany.
 * Alexander Diedrich, Helmut-Schmidt-University, Hamburg, Germany.
 * [Timo P. Gros](https://mosi.uni-saarland.de/people/timo/), German Research Center for Artificial Intelligence (DFKI), Saarbrücken, Germany.

--- a/prl2026-icaps/README.md
+++ b/prl2026-icaps/README.md
@@ -186,7 +186,6 @@ We do not insist on papers being submitted anonymously initially; this decision 
 
 ## Organizing Committee
 * [Zlatan Ajanović](https://zlatanajanovic.com), RWTH Aachen University, Aachen, Germany.
-* [Dillon Ze Chen](https://dillonzchen.github.io), Laboratory for Analysis and Architecture of Systems (LAAS-CNRS), Toulouse, France.
 * [Forest Agostinelli](https://cse.sc.edu/%7Eforesta/), University of South Carolina, Columbia, USA.
 * [Timo P. Gros](https://mosi.uni-saarland.de/people/timo/), German Research Center for Artificial Intelligence (DFKI), Saarbrücken, Germany.
 <!-- * [Sarah Keren](https://sarahk.cs.technion.ac.il), Technion, Israel Institute of Technology, Haifa, Israel. -->


### PR DESCRIPTION
Removes Dillon Ze Chen from the PRL 2026 organizing committee in both workshop pages:

- `prl2026-icaps/README.md` (PRL @ ICAPS 2026)
- `caipi_prl2026-ijcai/README.md` (CAIPI/PRL @ IJCAI 2026)

Each change removes only the single committee-member line; no other content is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)